### PR TITLE
Update AMBuildScript

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -141,6 +141,7 @@ class SM:
 				self.compiler.AddToListVar('CFLAGS', '-g3')
 				self.compiler.AddToListVar('CFLAGS', '-m32')
 				self.compiler.AddToListVar('POSTLINKFLAGS', '-m32')
+				self.compiler.AddToListVar('POSTLINKFLAGS', '-lstdc++')
 				self.compiler.AddToListVar('CXXFLAGS', '-fno-exceptions')
 				self.compiler.AddToListVar('CXXFLAGS', '-fno-threadsafe-statics')
 				self.compiler.AddToListVar('CXXFLAGS', '-Wno-non-virtual-dtor')


### PR DESCRIPTION
[Core / AMBuild] Fix : vphysics.ext.2.csgo.so: undefined symbol: __gxx_personality_v0